### PR TITLE
ci: add deadcode check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,13 @@ jobs:
         run: go install golang.org/x/tools/cmd/deadcode@v0.45.0
 
       - name: Deadcode
-        run: '"$(go env GOPATH)/bin/deadcode" -test ./...'
+        run: |
+          output_file=$(mktemp)
+          "$(go env GOPATH)/bin/deadcode" -test ./... > "$output_file"
+          if [ -s "$output_file" ]; then
+            cat "$output_file"
+            exit 1
+          fi
 
       - name: Test
         run: go test ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,12 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      - name: Install deadcode
+        run: go install golang.org/x/tools/cmd/deadcode@v0.45.0
+
+      - name: Deadcode
+        run: '"$(go env GOPATH)/bin/deadcode" -test ./...'
+
       - name: Test
         run: go test ./...
 

--- a/internal/routing/queue/queue.go
+++ b/internal/routing/queue/queue.go
@@ -20,22 +20,6 @@ func New(size int) *Queue {
 	return &Queue{ch: make(chan Task, size)}
 }
 
-func (q *Queue) Start(ctx context.Context) {
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case task, ok := <-q.ch:
-			if !ok {
-				return
-			}
-			if task != nil {
-				_ = task(ctx)
-			}
-		}
-	}
-}
-
 func (q *Queue) Enqueue(task Task) bool {
 	q.mu.Lock()
 	defer q.mu.Unlock()


### PR DESCRIPTION
## Summary
- add an enforced Go deadcode CI gate pinned to `golang.org/x/tools/cmd/deadcode@v0.45.0`
- remove unreachable helpers reported by deadcode\n- make the workflow fail when deadcode emits findings

## Validation
- `git diff --check`
- `go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...`
- `go test -count=1 ./...`
- `go build ./cmd/clawgo`
- `autoreview --mode branch --base origin/main --no-web-search --thinking low` clean
